### PR TITLE
test: add Catch2 unit-test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    name: ${{ matrix.compiler }} / ${{ matrix.backend }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - compiler: gcc
+            backend: CPP
+          - compiler: gcc
+            backend: OMP
+          - compiler: clang
+            backend: CPP
+          - compiler: clang
+            backend: OMP
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clang and OpenMP
+        if: matrix.compiler == 'clang'
+        run: sudo apt-get update && sudo apt-get install -y clang libomp-dev
+
+      - name: Select compiler
+        run: |
+          if [ "${{ matrix.compiler }}" = "clang" ]; then
+            echo "CC=clang" >> "$GITHUB_ENV"
+            echo "CXX=clang++" >> "$GITHUB_ENV"
+          else
+            echo "CC=gcc" >> "$GITHUB_ENV"
+            echo "CXX=g++" >> "$GITHUB_ENV"
+          fi
+
+      - name: Configure
+        run: cmake -S tests -B build -DCMAKE_BUILD_TYPE=Release -DMCBOOSTER_BACKEND=${{ matrix.backend }}
+
+      - name: Build
+        run: cmake --build build -j
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 webpage/
 build/
+build*/
 .settings/
 .cproject
 .project
+
+# Symlink to AGENTS.md
+CLAUDE.md
+.claude/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# Agents notes
+
+MCBooster is a **header-only** C++11 library for fast generation of phase-space Monte Carlo events (particle decays, up to nine final-state particles). It is built on [Thrust](https://thrust.github.io/), so the same source compiles to CUDA (GPU), OpenMP, TBB, or single-threaded CPP backends. The algorithm follows ROOT's `TGenPhaseSpace` / CERNLIB GENBOD (Raubold–Lynch method).
+
+This is the **GooFit fork** of the original MultithreadCorner/MCBooster. There are no tagged releases here; it tracks GooFit's needs.
+
+Library lives in `mcbooster/` (all headers). `src/` holds example programs, not library code.
+
+## Build & run
+
+The library itself needs no build — just put `mcbooster/` on the include path. The CMake build only compiles the examples in `src/`.
+
+```bash
+mkdir build && cd build
+cmake ../          # prints the install prefix; add -DCMAKE_INSTALL_PREFIX=<path> for non-root
+make
+```
+
+Requirements for examples: Thrust ≥1.8, [ROOT](https://root.cern.ch/), [TCLAP](http://tclap.sourceforge.net/) (all `find_package`'d as REQUIRED). CUDA ≥6.5 is optional — if absent, only the `*_OpenMP_GCC_*` targets build.
+
+## Tests
+
+`tests/` holds a Catch2 unit-test suite (the example executables above are *not* tests). It is a self-contained CMake project that pulls in Thrust and Catch2 via FetchContent — no ROOT, TCLAP, or CUDA needed — pinned to the versions GooFit uses (Thrust 1.8.3, Catch2 v2.13.9). The backend defaults to the CPU `CPP` Thrust backend, so the suite builds and runs with only a C++11 compiler.
+
+```bash
+cmake -S tests -B build-tests -DMCBOOSTER_BACKEND=CPP   # or OMP
+cmake --build build-tests -j
+ctest --test-dir build-tests --output-on-failure
+```
+
+`.github/workflows/ci.yml` runs this on gcc and clang × `CPP`/`OMP`. Coverage: `test_vector4r` (Lorentz/3-vector math), `test_generate` (`PhaseSpace` mass/conservation/weights/unweighting), `test_evaluate` (`EvaluateArray` with a user `IFunctionArray`, mirroring GooFit's usage). Tests use only the public `mcbooster::` types so they are backend-agnostic.
+
+Example executables follow `MCBooster_Example_<BACKEND_AND_COMPILER>_<NAME>`:
+- `*_B2KPiJpsi` (`src/Generate.cu`/`.cpp`) — generates B0→J/ψ K π and evaluates kinematic variables in parallel.
+- `*_GenerateSample` (`src/GenerateSample.cu`) — CLI-driven generator that writes a ROOT TTree.
+- `*_PerformanceTest` (`src/PerformanceTest.cu`/`.cpp`) — timing vs. number of events/particles.
+- `*_CompareWithRoot` (`src/CompareWithTGenPhaseSpace.cu`) — validates against ROOT.
+
+The `.cu` and `.cpp` files for a given example are usually **the same code** — `.cu` is compiled by nvcc, `.cpp` by gcc for the OpenMP-only path. Keep them in sync when editing.
+
+## Backend selection (key concept)
+
+The backend is chosen at compile time via the `MCBOOSTER_BACKEND` macro (`CUDA`, `OMP`, `TBB`, or `CPP`), defaulting to `CUDA` (`mcbooster/Config.h`). Examples set it with `-DMCBOOSTER_BACKEND=OMP`. Because everything routes through Thrust execution policies, **writing code only with MCBooster's provided types lets you switch backends just by recompiling** (often literally `.cu` → `.cpp`).
+
+## Architecture
+
+Everything is in `namespace mcbooster`. Headers include each other through `mcbooster/Config.h`, which selects the backend and pulls in Thrust.
+
+- **`GTypes.h`** — portable scalar typedefs (`GReal_t` is `double`, or `float` under `-DFP_SINGLE`; `GInt_t`, `GBool_t`, etc.). `kMAXP 9` caps the number of particles. Use these types everywhere instead of raw C++ types.
+- **`GContainers.h` / `GContainersHost.h`** — the container layer. `mc_device_vector<T>` / `mc_host_vector<T>` wrap Thrust vectors so user code stays backend-agnostic. Domain typedefs: `RealVector_d`, `BoolVector_d`, `Particles_d` (a `Vector4R` device vector), and the set types `ParticlesSet_d` / `VariableSet_d` (STL vectors of pointers to those device vectors — one entry per particle/variable).
+- **`Vector4R.h` / `Vector3R.h`** — `__host__ __device__` Lorentz/3-vector math used inside functors and user kinematics code.
+- **`Generate.h`** — the core. `class PhaseSpace` is the generator: construct with mother mass, daughter masses, and event count; call `Generate(mother)`, then `Unweight()`, then `Export(Events*)` (or `ExportUnweighted`). `struct Events` is the host-side output container. Generation runs the `functors/` as Thrust transforms.
+- **`Evaluate.h` / `EvaluateArray.h`** — free function templates that run a user functor over a `ParticlesSet_d` in parallel. `Evaluate` returns one value per event; `EvaluateArray` fills a `VariableSet_d` (several variables per event in one pass). Overloads target host output, device output, or in-place.
+- **`GFunctional.h`** — the two abstract functor interfaces users subclass: `IFunction<RESULT>` (one value) and `IFunctionArray` (fills a `GReal_t*` array). Both declare `__host__ __device__ virtual operator()` taking `Vector4R** particles`.
+- **`functors/`** — internal Thrust functors driving generation: `DecayMother`/`DecayMothers` (single fixed mother vs. per-event mothers, for sequential decays), `RandGen`, `FlagAcceptReject` + `IsAccepted` (the unweighting), `Calculate`.
+- **`strided_iterator.h`** — iterator helper for interleaved data layouts.
+
+`MCBooster.h` is generated by CMake from `MCBooster.h.in` (carries the version); the committed copy may be regenerated by a `cmake` run.
+
+## Conventions
+
+- `GReal_t` not `double`, `GInt_t` not `int`, etc. — this preserves the `FP_SINGLE` switch and portability.
+- Functions touching kinematics are marked `__host__ __device__` so they work on both backends.
+- New headers should include `mcbooster/Config.h` (directly or transitively) before using Thrust.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,78 @@
+# Self-contained test build for MCBooster.
+#
+# MCBooster is header-only, so this project pulls in its two test-only
+# dependencies (Thrust and Catch2) via FetchContent and never touches the
+# ROOT/TCLAP example build at the repo root. Run it standalone:
+#
+#   cmake -S tests -B build-tests
+#   cmake --build build-tests
+#   ctest --test-dir build-tests --output-on-failure
+#
+# The backend is selected with -DMCBOOSTER_BACKEND=CPP|OMP (default CPP), so CI
+# can exercise the library with no CUDA toolkit installed.
+
+cmake_minimum_required(VERSION 3.14)
+project(MCBoosterTests CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(MCBOOSTER_BACKEND "CPP" CACHE STRING "Thrust backend for the tests: CPP or OMP")
+set_property(CACHE MCBOOSTER_BACKEND PROPERTY STRINGS CPP OMP)
+
+include(FetchContent)
+
+# Thrust: pinned to the exact commit GooFit vendors for its host/OMP builds
+# (extern/thrust in GooFit#379; THRUST_VERSION 100803). The CCCL 3.0 path GooFit
+# uses only applies to its CUDA 13 builds, which these CPU/OMP tests do not take.
+FetchContent_Declare(
+  thrust
+  GIT_REPOSITORY https://github.com/NVIDIA/thrust.git
+  GIT_TAG 8551c97870cd722486ba7834ae9d867f13e299ad)
+# Populate only -- Thrust 1.8.3 ships a legacy CMakeLists we do not want to run.
+FetchContent_GetProperties(thrust)
+if(NOT thrust_POPULATED)
+  FetchContent_Populate(thrust)
+endif()
+
+# Catch2 v2: the last single-header, C++11-friendly line. Pinned to the same tag
+# GooFit vendors (extern/catch2 in GooFit#379).
+FetchContent_Declare(
+  catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v2.13.9
+  GIT_SHALLOW TRUE)
+FetchContent_MakeAvailable(catch2)
+
+# INTERFACE target carrying everything needed to compile against the library.
+add_library(mcbooster INTERFACE)
+target_include_directories(mcbooster INTERFACE "${PROJECT_SOURCE_DIR}/.." "${thrust_SOURCE_DIR}")
+target_compile_definitions(mcbooster INTERFACE MCBOOSTER_BACKEND=${MCBOOSTER_BACKEND})
+
+if(MCBOOSTER_BACKEND STREQUAL "OMP")
+  find_package(OpenMP REQUIRED)
+  target_link_libraries(mcbooster INTERFACE OpenMP::OpenMP_CXX)
+  target_compile_definitions(
+    mcbooster INTERFACE THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_OMP
+                        THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP)
+else()
+  target_compile_definitions(
+    mcbooster INTERFACE THRUST_DEVICE_SYSTEM=THRUST_DEVICE_SYSTEM_CPP
+                        THRUST_HOST_SYSTEM=THRUST_HOST_SYSTEM_CPP)
+endif()
+
+message(STATUS "MCBooster tests backend: ${MCBOOSTER_BACKEND}")
+
+# Catch2's main(), compiled once and shared across the test executables.
+add_library(catch_main STATIC catch_main.cpp)
+target_link_libraries(catch_main PUBLIC Catch2::Catch2)
+
+enable_testing()
+
+set(MCBOOSTER_TESTS test_vector4r test_generate test_evaluate)
+foreach(test IN LISTS MCBOOSTER_TESTS)
+  add_executable(${test} ${test}.cpp)
+  target_link_libraries(${test} PRIVATE mcbooster catch_main)
+  add_test(NAME ${test} COMMAND ${test})
+endforeach()

--- a/tests/catch_main.cpp
+++ b/tests/catch_main.cpp
@@ -1,0 +1,4 @@
+// Provides Catch2's main(). Kept in its own TU so the (slow) Catch2 main is
+// compiled once and linked into every test executable.
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/tests/test_evaluate.cpp
+++ b/tests/test_evaluate.cpp
@@ -1,0 +1,67 @@
+// Exercises EvaluateArray with a user IFunctionArray functor -- the exact
+// pattern GooFit uses to compute kinematic variables (e.g. Dim5) in parallel
+// over a generated sample.
+#include <catch2/catch.hpp>
+
+#include <vector>
+
+#include <mcbooster/EvaluateArray.h>
+#include <mcbooster/GContainers.h>
+#include <mcbooster/GFunctional.h>
+#include <mcbooster/Generate.h>
+#include <mcbooster/Vector4R.h>
+
+using mcbooster::GInt_t;
+using mcbooster::GReal_t;
+using mcbooster::Vector4R;
+
+namespace {
+// Computes the three two-body invariant masses of a 3-body final state.
+struct InvariantMasses : public mcbooster::IFunctionArray {
+    InvariantMasses() { dim = 3; }
+
+    __host__ __device__ void operator()(const GInt_t, Vector4R **p, GReal_t *out) override {
+        out[0] = (*p[0] + *p[1]).mass();
+        out[1] = (*p[0] + *p[2]).mass();
+        out[2] = (*p[1] + *p[2]).mass();
+    }
+};
+
+const GReal_t kMotherMass = 1.86484;
+const std::vector<GReal_t> kMasses{0.493677, 0.139570, 0.134977};
+const mcbooster::GLong_t kNEvents = 2000;
+} // namespace
+
+TEST_CASE("EvaluateArray matches a host-side recomputation", "[evaluate]") {
+    mcbooster::PhaseSpace phsp(kMotherMass, kMasses, kNEvents);
+    phsp.Generate(Vector4R(kMotherMass, 0.0, 0.0, 0.0));
+
+    mcbooster::ParticlesSet_d particles{&phsp.GetDaughters(0), &phsp.GetDaughters(1), &phsp.GetDaughters(2)};
+
+    mcbooster::RealVector_h m01(kNEvents);
+    mcbooster::RealVector_h m02(kNEvents);
+    mcbooster::RealVector_h m12(kNEvents);
+    mcbooster::VariableSet_h variables{&m01, &m02, &m12};
+
+    InvariantMasses functor;
+    mcbooster::EvaluateArray<InvariantMasses>(functor, particles, variables);
+
+    // Recompute on the host straight from the daughter four-vectors.
+    mcbooster::Particles_h d0 = phsp.GetDaughters(0);
+    mcbooster::Particles_h d1 = phsp.GetDaughters(1);
+    mcbooster::Particles_h d2 = phsp.GetDaughters(2);
+
+    const GReal_t lo01 = kMasses[0] + kMasses[1];
+    const GReal_t hi01 = kMotherMass - kMasses[2];
+
+    for(int i = 0; i < kNEvents; i++) {
+        INFO("event " << i);
+        CHECK(m01[i] == Approx((d0[i] + d1[i]).mass()).epsilon(1e-6));
+        CHECK(m02[i] == Approx((d0[i] + d2[i]).mass()).epsilon(1e-6));
+        CHECK(m12[i] == Approx((d1[i] + d2[i]).mass()).epsilon(1e-6));
+
+        // And the invariant mass must respect the Dalitz boundaries.
+        CHECK(m01[i] >= Approx(lo01).epsilon(1e-5));
+        CHECK(m01[i] <= Approx(hi01).epsilon(1e-5));
+    }
+}

--- a/tests/test_generate.cpp
+++ b/tests/test_generate.cpp
@@ -1,0 +1,86 @@
+// Exercises the core phase-space generator (PhaseSpace::Generate) that GooFit
+// uses to produce normalization/toy samples. Runs on whichever Thrust backend
+// the build selects.
+#include <catch2/catch.hpp>
+
+#include <cmath>
+#include <vector>
+
+#include <mcbooster/GContainers.h>
+#include <mcbooster/Generate.h>
+#include <mcbooster/Vector4R.h>
+
+using mcbooster::GReal_t;
+using mcbooster::PhaseSpace;
+using mcbooster::Vector4R;
+
+namespace {
+// D0 -> K- pi+ pi0, a realistic 3-body decay.
+const GReal_t kMotherMass = 1.86484;
+const std::vector<GReal_t> kMasses{0.493677, 0.139570, 0.134977};
+const mcbooster::GLong_t kNEvents = 5000;
+} // namespace
+
+TEST_CASE("PhaseSpace reports its configuration", "[generate]") {
+    PhaseSpace phsp(kMotherMass, kMasses, kNEvents);
+    CHECK(phsp.GetNDaughters() == 3);
+    CHECK(phsp.GetNEvents() == kNEvents);
+}
+
+TEST_CASE("Generated daughters have the requested masses", "[generate]") {
+    PhaseSpace phsp(kMotherMass, kMasses, kNEvents);
+    phsp.Generate(Vector4R(kMotherMass, 0.0, 0.0, 0.0));
+
+    for(int d = 0; d < 3; d++) {
+        mcbooster::Particles_h daughters = phsp.GetDaughters(d);
+        for(int i = 0; i < 50; i++) {
+            INFO("daughter " << d << ", event " << i);
+            CHECK(daughters[i].mass() == Approx(kMasses[d]).epsilon(1e-5));
+        }
+    }
+}
+
+TEST_CASE("Generation conserves energy and momentum", "[generate]") {
+    PhaseSpace phsp(kMotherMass, kMasses, kNEvents);
+    phsp.Generate(Vector4R(kMotherMass, 0.0, 0.0, 0.0));
+
+    mcbooster::Particles_h d0 = phsp.GetDaughters(0);
+    mcbooster::Particles_h d1 = phsp.GetDaughters(1);
+    mcbooster::Particles_h d2 = phsp.GetDaughters(2);
+
+    for(int i = 0; i < 50; i++) {
+        Vector4R total = d0[i] + d1[i] + d2[i];
+        INFO("event " << i);
+        CHECK(total.get(0) == Approx(kMotherMass).epsilon(1e-5)); // energy -> mother mass
+        CHECK(total.get(1) == Approx(0.0).margin(1e-5));          // px
+        CHECK(total.get(2) == Approx(0.0).margin(1e-5));          // py
+        CHECK(total.get(3) == Approx(0.0).margin(1e-5));          // pz
+        CHECK(total.mass() == Approx(kMotherMass).epsilon(1e-5));
+    }
+}
+
+TEST_CASE("Weights are finite and positive", "[generate]") {
+    PhaseSpace phsp(kMotherMass, kMasses, kNEvents);
+    phsp.Generate(Vector4R(kMotherMass, 0.0, 0.0, 0.0));
+
+    mcbooster::RealVector_h weights = phsp.GetWeights();
+    REQUIRE(weights.size() == static_cast<size_t>(kNEvents));
+
+    GReal_t sum = 0.0;
+    for(size_t i = 0; i < weights.size(); i++) {
+        INFO("event " << i);
+        REQUIRE(std::isfinite(weights[i]));
+        REQUIRE(weights[i] > 0.0);
+        sum += weights[i];
+    }
+    CHECK(sum > 0.0);
+}
+
+TEST_CASE("Unweighting keeps a subset of events", "[generate]") {
+    PhaseSpace phsp(kMotherMass, kMasses, kNEvents);
+    phsp.Generate(Vector4R(kMotherMass, 0.0, 0.0, 0.0));
+
+    mcbooster::GULong_t kept = phsp.Unweight();
+    CHECK(kept > 0);
+    CHECK(kept <= static_cast<mcbooster::GULong_t>(kNEvents));
+}

--- a/tests/test_vector4r.cpp
+++ b/tests/test_vector4r.cpp
@@ -1,0 +1,80 @@
+// Exercises the Lorentz-vector math that user kinematics code (and GooFit's
+// Amp3Body/Amp4Body PDFs) relies on. Pure host code -- no Thrust execution.
+#include <catch2/catch.hpp>
+
+#include <mcbooster/Vector4R.h>
+
+using mcbooster::GReal_t;
+using mcbooster::Vector4R;
+
+TEST_CASE("Vector4R component access", "[vector4r]") {
+    Vector4R v(5.0, 1.0, 2.0, 3.0);
+    CHECK(v.get(0) == Approx(5.0));
+    CHECK(v.get(1) == Approx(1.0));
+    CHECK(v.get(2) == Approx(2.0));
+    CHECK(v.get(3) == Approx(3.0));
+
+    v.set(2, 9.0);
+    CHECK(v.get(2) == Approx(9.0));
+
+    v.set(7.0, 0.0, 0.0, 1.0);
+    CHECK(v.get(0) == Approx(7.0));
+    CHECK(v.get(3) == Approx(1.0));
+}
+
+TEST_CASE("Vector4R invariant mass", "[vector4r]") {
+    // E^2 - |p|^2 = 25 - 9 = 16
+    Vector4R v(5.0, 1.0, 2.0, 2.0);
+    CHECK(v.mass2() == Approx(16.0));
+    CHECK(v.mass() == Approx(4.0));
+}
+
+TEST_CASE("Vector4R Minkowski dot product", "[vector4r]") {
+    Vector4R a(5.0, 1.0, 2.0, 2.0);
+    Vector4R b(3.0, 1.0, 0.0, 1.0);
+
+    // operator* is the Minkowski product: t1*t2 - (x1*x2 + y1*y2 + z1*z2)
+    //   = 15 - (1 + 0 + 2) = 12
+    CHECK((a * b) == Approx(12.0));
+    CHECK((a * a) == Approx(a.mass2()));
+
+    // dot() is the spatial 3-vector product: x1*x2 + y1*y2 + z1*z2 = 1 + 0 + 2
+    CHECK(a.dot(b) == Approx(3.0));
+}
+
+TEST_CASE("Vector4R addition and subtraction", "[vector4r]") {
+    Vector4R a(5.0, 1.0, 2.0, 2.0);
+    Vector4R b(3.0, 1.0, 0.0, 1.0);
+
+    Vector4R sum = a + b;
+    CHECK(sum.get(0) == Approx(8.0));
+    CHECK(sum.get(1) == Approx(2.0));
+    CHECK(sum.get(2) == Approx(2.0));
+    CHECK(sum.get(3) == Approx(3.0));
+
+    Vector4R diff = a - b;
+    CHECK(diff.get(0) == Approx(2.0));
+    CHECK(diff.get(1) == Approx(0.0));
+    CHECK(diff.get(2) == Approx(2.0));
+    CHECK(diff.get(3) == Approx(1.0));
+}
+
+TEST_CASE("Lorentz boost preserves invariant mass", "[vector4r]") {
+    // applyBoostTo(p4) boosts by p4's velocity (beta = p/E); any such boost
+    // leaves the Minkowski norm of the boosted vector unchanged.
+    Vector4R frame(5.0, 1.0, 2.0, 2.0); // mass 4
+    Vector4R p(4.0, 1.0, 1.0, 1.0);     // mass^2 = 16 - 3 = 13
+
+    GReal_t m2_before = p.mass2();
+    p.applyBoostTo(frame);
+    CHECK(p.mass2() == Approx(m2_before));
+
+    // The inverse boost by a vector's own velocity returns it to rest:
+    // momentum -> 0 and energy -> the rest mass.
+    Vector4R q(5.0, 1.0, 2.0, 2.0);
+    q.applyBoostTo(frame, /*inverse=*/true);
+    CHECK(q.get(1) == Approx(0.0).margin(1e-12));
+    CHECK(q.get(2) == Approx(0.0).margin(1e-12));
+    CHECK(q.get(3) == Approx(0.0).margin(1e-12));
+    CHECK(q.get(0) == Approx(frame.mass()));
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## What

MCBooster is header-only and had no test suite — "running tests" meant compiling the ROOT/TCLAP-dependent example executables and eyeballing output. This adds a real unit-test suite and CI.

## `tests/`

A self-contained CMake project that pulls **Thrust** and **Catch2** via FetchContent — no ROOT, TCLAP, or CUDA required. Versions are pinned to what GooFit actually compiles MCBooster against (Thrust `1.8.3` commit `8551c978`, Catch2 `v2.13.9`); the CCCL 3.0 path only applies to GooFit's CUDA-13 build, which the CPU/OMP tests here don't take.

```bash
cmake -S tests -B build -DMCBOOSTER_BACKEND=CPP   # or OMP
cmake --build build -j
ctest --test-dir build --output-on-failure
```

Coverage (uses only public `mcbooster::` types, so it's backend-agnostic):
- **`test_vector4r`** — Lorentz/3-vector math: components, invariant mass, Minkowski vs. spatial products, boost preserving invariant mass.
- **`test_generate`** — `PhaseSpace`: daughter masses match inputs, energy/momentum conservation, weights finite & positive, unweighting keeps a valid subset.
- **`test_evaluate`** — `EvaluateArray` driven by a user `IFunctionArray`, cross-checked against a host recomputation. Mirrors how GooFit uses MCBooster (cf. its `VectorsTest.cu` / `Dim5`).

## CI

`.github/workflows/ci.yml` builds and runs the suite on **gcc and clang × CPP and OMP** backends on every push/PR.

## Validation

All 3 tests pass locally on **both** the CPP and OMP backends.

## Notes

- Tests live in a standalone `tests/` CMake project rather than the root `CMakeLists.txt`, because the root build hard-requires ROOT/TCLAP. Easy to integrate behind an option later if preferred.
- This PR also adds `CLAUDE.md` (previously untracked locally) with a documented Tests section. Drop that file from the PR if you'd rather keep it local.